### PR TITLE
fix: follow best practice of Hono

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,14 +2,16 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { CoreMessage, streamText } from 'ai';
 import { env } from 'cloudflare:workers';
 import { verifySignature, streamResponse } from '@layercode/node-server-sdk';
-import { Context } from 'hono';
+import { Hono } from 'hono';
 
 const sessionMessages = {} as Record<string, CoreMessage[]>;
 
 const SYSTEM_PROMPT = `You are a helpful conversation assistant. You should respond to the user's message in a conversational manner. Your output will be spoken by a TTS model. You should respond in a way that is easy for the TTS model to speak and sound natural.`;
 const WELCOME_MESSAGE = 'Welcome to Layercode. How can I help you today?';
 
-export const onRequestPost = async (c: Context) => {
+const app = new Hono();
+
+app.post('/', async (c) => {
   if (!env.GOOGLE_GENERATIVE_AI_API_KEY) {
     return c.json({ error: 'GOOGLE_GENERATIVE_AI_API_KEY is not set' }, 500);
   }
@@ -68,4 +70,6 @@ export const onRequestPost = async (c: Context) => {
     // Here we return the textStream chunks as SSE messages to Layercode, to be spoken to the user
     await stream.ttsTextStream(textStream);
   });
-};
+});
+
+export { app };

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -1,7 +1,9 @@
-import { Context } from 'hono';
+import { Hono } from 'hono';
 import { env } from 'cloudflare:workers';
 
-export const onRequestPost = async (c: Context) => {
+const app = new Hono();
+
+app.post('/', async (c) => {
   try {
     const response = await fetch("https://api.layercode.com/v1/pipelines/authorize_session", {
       method: 'POST',
@@ -20,4 +22,6 @@ export const onRequestPost = async (c: Context) => {
   } catch (error) {
     return c.json({ error: error });
   }
-};
+});
+
+export { app }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 import { Hono } from 'hono';
-import { onRequestPost as onRequestPostAgent } from './agent';
-import { onRequestPost as onRequestPostAuthorize } from './authorize';
+import { app as agentApp } from './agent';
+import { app as authorizeApp } from './authorize';
 import { cors } from 'hono/cors'
 
 const app = new Hono();
 
-app.post('/agent', onRequestPostAgent);
+app.route('/agent', agentApp);
 
 app.use('/authorize', cors())
-app.post('/authorize', onRequestPostAuthorize);
+app.route('/authorize', authorizeApp);
 
 
 export default app;


### PR DESCRIPTION
Hi!
I was looking at the layercode code and was curious about something, so I'm sending you a PR.

Before this change, the code created ‘Ruby on Rails-like Controllers’ for each route. This is like an 'anti-pattern' in Hono.
https://hono.dev/docs/guides/best-practices

This PR changes the code to be in line with Hono's best practice.